### PR TITLE
Add fallback for runner twitch name being null/undefined

### DIFF
--- a/extension/index.js
+++ b/extension/index.js
@@ -200,7 +200,8 @@ module.exports = async (nodecg) => {
                     let i = 0;
                     newVal.teams.forEach(team => {
                         team.players.forEach(player => {
-                            activeRunners.value[i].streamKey = player.social.twitch;
+                            // Prefer twitch name, but if it's unset fall back to username (which cannot be null)
+                            activeRunners.value[i].streamKey = player.social.twitch || player.social.name;
                             i++;
                         })
                     })


### PR DESCRIPTION
Another small bugfix for something I noticed. If a runner has a null twitch name their stream key will become "undefined" when the auto stream key switcher runs. This falls back to using a runner's display name, since speedcontrol will not allow that to be null.